### PR TITLE
fix retain circle in RMUniversalAlert

### DIFF
--- a/RMUniversalAlert.m
+++ b/RMUniversalAlert.m
@@ -46,6 +46,8 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
     alert.hasDestructiveButton = destructiveButtonTitle != nil;
     alert.hasOtherButtons = otherButtonTitles.count > 0;
     
+    __weak RMUniversalAlert *weakAlert = alert;
+    
     if ([UIAlertController class]) {
         alert.alertController = [UIAlertController showAlertInViewController:viewController
                                                                    withTitle:title message:message
@@ -54,7 +56,7 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
                                                            otherButtonTitles:otherButtonTitles
                                                                     tapBlock:^(UIAlertController *controller, UIAlertAction *action, NSInteger buttonIndex){
                                                                         if (tapBlock) {
-                                                                            tapBlock(alert, buttonIndex);
+                                                                            tapBlock(weakAlert, buttonIndex);
                                                                         }
                                                                     }];
     } else {
@@ -75,17 +77,17 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
                                              tapBlock:^(UIAlertView *alertView, NSInteger buttonIndex){
                                                  if (tapBlock) {
                                                      if (buttonIndex == alertView.cancelButtonIndex) {
-                                                         tapBlock(alert, RMUniversalAlertCancelButtonIndex);
+                                                         tapBlock(weakAlert, RMUniversalAlertCancelButtonIndex);
                                                      } else if (destructiveButtonTitle) {
                                                          if (buttonIndex == alertView.firstOtherButtonIndex) {
-                                                             tapBlock(alert, RMUniversalAlertDestructiveButtonIndex);
+                                                             tapBlock(weakAlert, RMUniversalAlertDestructiveButtonIndex);
                                                          } else if (otherButtonTitles.count) {
                                                              NSInteger otherOffset = buttonIndex - alertView.firstOtherButtonIndex;
-                                                             tapBlock(alert, RMUniversalAlertFirstOtherButtonIndex + otherOffset - 1);
+                                                             tapBlock(weakAlert, RMUniversalAlertFirstOtherButtonIndex + otherOffset - 1);
                                                          }
                                                      } else if (otherButtonTitles.count) {
                                                          NSInteger otherOffset = buttonIndex - alertView.firstOtherButtonIndex;
-                                                         tapBlock(alert, RMUniversalAlertFirstOtherButtonIndex + otherOffset);
+                                                         tapBlock(weakAlert, RMUniversalAlertFirstOtherButtonIndex + otherOffset);
                                                      }
                                                  }
                                              }];
@@ -109,6 +111,8 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
     alert.hasDestructiveButton = destructiveButtonTitle != nil;
     alert.hasOtherButtons = otherButtonTitles.count > 0;
     
+    __weak RMUniversalAlert *weakAlert = alert;
+    
     if ([UIAlertController class]) {
         
         alert.alertController = [UIAlertController showActionSheetInViewController:viewController
@@ -130,7 +134,7 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
                                                 }
                                                                           tapBlock:^(UIAlertController *controller, UIAlertAction *action, NSInteger buttonIndex){
                                                                               if (tapBlock) {
-                                                                                  tapBlock(alert, buttonIndex);
+                                                                                  tapBlock(weakAlert, buttonIndex);
                                                                               }
                                                                           }];
     } else {
@@ -138,12 +142,12 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
         void(^actionSheetTapBlock)(UIActionSheet *actionSheet, NSInteger buttonIndex) = ^(UIActionSheet *actionSheet, NSInteger buttonIndex){
             if (tapBlock) {
                 if (buttonIndex == actionSheet.cancelButtonIndex) {
-                    tapBlock(alert, RMUniversalAlertCancelButtonIndex);
+                    tapBlock(weakAlert, RMUniversalAlertCancelButtonIndex);
                 } else if (buttonIndex == actionSheet.destructiveButtonIndex) {
-                    tapBlock(alert, RMUniversalAlertDestructiveButtonIndex);
+                    tapBlock(weakAlert, RMUniversalAlertDestructiveButtonIndex);
                 } else if (otherButtonTitles.count) {
                     NSInteger otherOffset = buttonIndex - actionSheet.firstOtherButtonIndex;
-                    tapBlock(alert, RMUniversalAlertFirstOtherButtonIndex + otherOffset);
+                    tapBlock(weakAlert, RMUniversalAlertFirstOtherButtonIndex + otherOffset);
                 }
             }
         };


### PR DESCRIPTION
I find that **RMUniversalAlert** strong retain **UIAlertController**, **UIAlertController** may strong retain **UIAlertAction**, **UIAlertAction** strong retain **UIAlertAction** and results the UIAlertController can not be released when it disappear. I change the alert to *weak* and solve it, please review the code ~