### PR TITLE
Remove weak reference

### DIFF
--- a/RMUniversalAlert.m
+++ b/RMUniversalAlert.m
@@ -46,8 +46,6 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
     alert.hasDestructiveButton = destructiveButtonTitle != nil;
     alert.hasOtherButtons = otherButtonTitles.count > 0;
     
-    __weak RMUniversalAlert *weakAlert = alert;
-    
     if ([UIAlertController class]) {
         alert.alertController = [UIAlertController showAlertInViewController:viewController
                                                                    withTitle:title message:message
@@ -56,7 +54,7 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
                                                            otherButtonTitles:otherButtonTitles
                                                                     tapBlock:^(UIAlertController *controller, UIAlertAction *action, NSInteger buttonIndex){
                                                                         if (tapBlock) {
-                                                                            tapBlock(weakAlert, buttonIndex);
+                                                                            tapBlock(alert, buttonIndex);
                                                                         }
                                                                     }];
     } else {
@@ -77,17 +75,17 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
                                              tapBlock:^(UIAlertView *alertView, NSInteger buttonIndex){
                                                  if (tapBlock) {
                                                      if (buttonIndex == alertView.cancelButtonIndex) {
-                                                         tapBlock(weakAlert, RMUniversalAlertCancelButtonIndex);
+                                                         tapBlock(alert, RMUniversalAlertCancelButtonIndex);
                                                      } else if (destructiveButtonTitle) {
                                                          if (buttonIndex == alertView.firstOtherButtonIndex) {
-                                                             tapBlock(weakAlert, RMUniversalAlertDestructiveButtonIndex);
+                                                             tapBlock(alert, RMUniversalAlertDestructiveButtonIndex);
                                                          } else if (otherButtonTitles.count) {
                                                              NSInteger otherOffset = buttonIndex - alertView.firstOtherButtonIndex;
-                                                             tapBlock(weakAlert, RMUniversalAlertFirstOtherButtonIndex + otherOffset - 1);
+                                                             tapBlock(alert, RMUniversalAlertFirstOtherButtonIndex + otherOffset - 1);
                                                          }
                                                      } else if (otherButtonTitles.count) {
                                                          NSInteger otherOffset = buttonIndex - alertView.firstOtherButtonIndex;
-                                                         tapBlock(weakAlert, RMUniversalAlertFirstOtherButtonIndex + otherOffset);
+                                                         tapBlock(alert, RMUniversalAlertFirstOtherButtonIndex + otherOffset);
                                                      }
                                                  }
                                              }];
@@ -111,8 +109,6 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
     alert.hasDestructiveButton = destructiveButtonTitle != nil;
     alert.hasOtherButtons = otherButtonTitles.count > 0;
     
-    __weak RMUniversalAlert *weakAlert = alert;
-    
     if ([UIAlertController class]) {
         
         alert.alertController = [UIAlertController showActionSheetInViewController:viewController
@@ -134,7 +130,7 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
                                                 }
                                                                           tapBlock:^(UIAlertController *controller, UIAlertAction *action, NSInteger buttonIndex){
                                                                               if (tapBlock) {
-                                                                                  tapBlock(weakAlert, buttonIndex);
+                                                                                  tapBlock(alert, buttonIndex);
                                                                               }
                                                                           }];
     } else {
@@ -142,12 +138,12 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
         void(^actionSheetTapBlock)(UIActionSheet *actionSheet, NSInteger buttonIndex) = ^(UIActionSheet *actionSheet, NSInteger buttonIndex){
             if (tapBlock) {
                 if (buttonIndex == actionSheet.cancelButtonIndex) {
-                    tapBlock(weakAlert, RMUniversalAlertCancelButtonIndex);
+                    tapBlock(alert, RMUniversalAlertCancelButtonIndex);
                 } else if (buttonIndex == actionSheet.destructiveButtonIndex) {
-                    tapBlock(weakAlert, RMUniversalAlertDestructiveButtonIndex);
+                    tapBlock(alert, RMUniversalAlertDestructiveButtonIndex);
                 } else if (otherButtonTitles.count) {
                     NSInteger otherOffset = buttonIndex - actionSheet.firstOtherButtonIndex;
-                    tapBlock(weakAlert, RMUniversalAlertFirstOtherButtonIndex + otherOffset);
+                    tapBlock(alert, RMUniversalAlertFirstOtherButtonIndex + otherOffset);
                 }
             }
         };

--- a/Tests/RMUniversalAlert/ViewController.m
+++ b/Tests/RMUniversalAlert/ViewController.m
@@ -21,7 +21,7 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 @property (strong, nonatomic) RMUniversalAlertCompletionBlock tapBlock;
 
-@property (strong, nonatomic) RMUniversalAlert *universalAlert;
+@property (weak, nonatomic) RMUniversalAlert *universalAlert;
 
 @end
 
@@ -85,6 +85,7 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 - (IBAction)singleDestructive:(UIButton *)sender
 {
+    __weak __typeof(self) weakSelf = self;
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -104,6 +105,9 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                              destructiveButtonTitle:@"Delete"
                                                                   otherButtonTitles:nil
                                                  popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
                                                      popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
@@ -116,6 +120,8 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 - (IBAction)singleOther:(UIButton *)sender
 {
+    __weak __typeof(self) weakSelf = self;
+    
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -134,7 +140,11 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                                   cancelButtonTitle:nil
                                                              destructiveButtonTitle:nil
                                                                   otherButtonTitles:@[@"Other"]
-                                                 popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){                                                     popover.sourceView = self.view;
+                                                 popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
+                                                     popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
                                                                            tapBlock:self.tapBlock];
@@ -146,6 +156,8 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 - (IBAction)multipleOther:(UIButton *)sender
 {
+    __weak __typeof(self) weakSelf = self;
+    
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -165,6 +177,9 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                              destructiveButtonTitle:nil
                                                                   otherButtonTitles:@[@"Other 1", @"Other 2"]
                                                  popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
                                                      popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
@@ -177,6 +192,8 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 - (IBAction)cancelAndDestructive:(UIButton *)sender
 {
+    __weak __typeof(self) weakSelf = self;
+    
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -196,6 +213,9 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                              destructiveButtonTitle:@"Delete"
                                                                   otherButtonTitles:nil
                                                  popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
                                                      popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
@@ -208,6 +228,8 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 - (IBAction)cancelAndOther:(UIButton *)sender
 {
+    __weak __typeof(self) weakSelf = self;
+    
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -227,6 +249,9 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                              destructiveButtonTitle:nil
                                                                   otherButtonTitles:@[@"Other"]
                                                  popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
                                                      popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
@@ -239,6 +264,8 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 - (IBAction)cancelAndMultipleOther:(UIButton *)sender
 {
+    __weak __typeof(self) weakSelf = self;
+    
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -258,6 +285,9 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                              destructiveButtonTitle:nil
                                                                   otherButtonTitles:@[@"Other 1", @"Other 2"]
                                                  popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
                                                      popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
@@ -270,6 +300,8 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 - (IBAction)destructiveAndOther:(UIButton *)sender
 {
+    __weak __typeof(self) weakSelf = self;
+    
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -289,6 +321,9 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                              destructiveButtonTitle:@"Delete"
                                                                   otherButtonTitles:@[@"Other"]
                                                  popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
                                                      popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
@@ -301,6 +336,8 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 - (IBAction)destructiveAndMultipleOther:(UIButton *)sender
 {
+    __weak __typeof(self) weakSelf = self;
+    
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -320,6 +357,9 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                              destructiveButtonTitle:@"Delete"
                                                                   otherButtonTitles:@[@"Other 1", @"Other 2"]
                                                  popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
                                                      popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
@@ -332,6 +372,8 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 - (IBAction)destructiveCancelAndOther:(UIButton *)sender
 {
+    __weak __typeof(self) weakSelf = self;
+    
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -351,6 +393,9 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                              destructiveButtonTitle:@"Delete"
                                                                   otherButtonTitles:@[@"Other"]
                                                  popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
                                                      popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
@@ -363,6 +408,8 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 
 - (IBAction)destructiveCancelAndMultipleOther:(UIButton *)sender
 {
+    __weak __typeof(self) weakSelf = self;
+    
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -382,6 +429,9 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                              destructiveButtonTitle:@"Delete"
                                                                   otherButtonTitles:@[@"Other"]
                                                  popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
                                                      popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
@@ -393,6 +443,8 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
 }
 
 - (IBAction)singleCancelWithDismiss:(UIButton*)sender {
+    __weak __typeof(self) weakSelf = self;
+    
     switch (self.mode) {
         case PresentationModeAlert: {
             self.universalAlert = [RMUniversalAlert showAlertInViewController:self
@@ -405,6 +457,9 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
             
             
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                __strong __typeof(weakSelf) self = weakSelf;
+                if (!self) return;
+                
                 [self.universalAlert dismissAlertAnimated:NO];
             });
             
@@ -418,11 +473,17 @@ typedef NS_ENUM(NSInteger, PresentationMode) {
                                                              destructiveButtonTitle:nil
                                                                   otherButtonTitles:nil
                                                  popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
+                                                     __strong __typeof(weakSelf) self = weakSelf;
+                                                     if (!self) return;
+                                                     
                                                      popover.sourceView = self.view;
                                                      popover.sourceRect = sender.frame;
                                                  }
                                                                            tapBlock:self.tapBlock];
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                __strong __typeof(weakSelf) self = weakSelf;
+                if (!self) return;
+                
                 [self.universalAlert dismissAlertAnimated:YES];
             });
             break;


### PR DESCRIPTION
This PR is a revert of #18.
And some codes are added on Sample codes.
- related issue : #23 

I think the alert should be referred by weak if the user needs to refer.
Because most of alerts don't need to have ownership.

What if you need to refer the alert, I think the following is better pratice.

``` objective-c
@interface ViewController ()
@property (weak, nonatomic) RMUniversalAlert *universalAlert;
@property (strong, nonatomic) RMUniversalAlertCompletionBlock tapBlock;
@end

...

- (void)createTabBlock {
    self.tapBlock = ^(RMUniversalAlert *alert, NSInteger buttonIndex){
            if (buttonIndex == alert.destructiveButtonIndex) {
                NSLog(@"Delete");
            } else if (buttonIndex == alert.cancelButtonIndex) {
                NSLog(@"Cancel");
            } else if (buttonIndex >= alert.firstOtherButtonIndex) {
                NSLog(@"Other %ld", (long)buttonIndex - alert.firstOtherButtonIndex + 1);
            }
        };

}

- (void)showAlert {

    self.universalAlert = [RMUniversalAlert showAlertInViewController:self
                                                                    withTitle:@"Title"
                                                                      message:@"Message"
                                                            cancelButtonTitle:@"Cancel"
                                                       destructiveButtonTitle:nil
                                                            otherButtonTitles:nil
                                                                     tapBlock:self.tapBlock];
}

- (void)showActionSheet {
   __weak __typeof(self) weakSelf = self;

    self.universalAlert = [RMUniversalAlert showActionSheetInViewController:self
                                                                          withTitle:@"Title"
                                                                            message:@"Message"
                                                                  cancelButtonTitle:@"Cancel"
                                                             destructiveButtonTitle:@"Delete"
                                                                  otherButtonTitles:@[@"Other"]
                                                 popoverPresentationControllerBlock:^(RMPopoverPresentationController *popover){
                                                     __strong __typeof(weakSelf) self = weakSelf;
                                                     if (!self) return;

                                                     popover.sourceView = self.view;
                                                     popover.sourceRect = sender.frame;
                                                 }
                                                                           tapBlock:self.tapBlock];
}

...
```

I'm looking forward to your feedback.
