### PR TITLE
Fix iPad crash issue of the actionsheet

### DIFF
--- a/RMUniversalAlert.m
+++ b/RMUniversalAlert.m
@@ -126,6 +126,11 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
                                                         popover.sourceView = configuredPopover.sourceView;
                                                         popover.sourceRect = configuredPopover.sourceRect;
                                                         popover.barButtonItem = configuredPopover.barButtonItem;
+                                                    } else {
+                                                        popover.sourceView = viewController.view;
+                                                        popover.sourceRect = viewController.view.bounds;
+                                                        
+                                                        popover.permittedArrowDirections = (UIPopoverArrowDirection) 0;
                                                     }
                                                 }
                                                                           tapBlock:^(UIAlertController *controller, UIAlertAction *action, NSInteger buttonIndex){


### PR DESCRIPTION
This PR is related to #20 issue.

When I show actionsheet on iPad using the following method, my app was always crashed without passing the **popoverPresentationControllerBlock**.

```objective-c
+ (instancetype)showActionSheetInViewController:(UIViewController *)viewController
                                      withTitle:(NSString *)title
                                        message:(NSString *)message
                              cancelButtonTitle:(NSString *)cancelButtonTitle
                         destructiveButtonTitle:(NSString *)destructiveButtonTitle
                              otherButtonTitles:(NSArray *)otherButtonTitles
             popoverPresentationControllerBlock:(void(^)(RMPopoverPresentationController *popover))popoverPresentationControllerBlock
                                       tapBlock:(RMUniversalAlertCompletionBlock)tapBlock;
```

So if the **popoverPresentationControllerBlock** is passed by **NULL** , 
I want to show the actionsheet on the center of parent view controller's view like `UIActionSheet`.

![simulator_screen_shot](https://cloud.githubusercontent.com/assets/5136232/20512199/4369e1c6-b0c1-11e6-9453-bdb39cacad0e.png)

Please consider this PR.
Thank you.
