### PR TITLE
Change embeded alert property attributes

### DIFF
--- a/RMUniversalAlert.m
+++ b/RMUniversalAlert.m
@@ -20,9 +20,9 @@ static NSInteger const RMUniversalAlertFirstOtherButtonIndex = 2;
 
 @interface RMUniversalAlert ()
 
-@property (nonatomic) UIAlertController *alertController;
-@property (nonatomic) UIAlertView *alertView;
-@property (nonatomic) UIActionSheet *actionSheet;
+@property (nonatomic, weak) UIAlertController *alertController;
+@property (nonatomic, weak) UIAlertView *alertView;
+@property (nonatomic, weak) UIActionSheet *actionSheet;
 
 @property (nonatomic, assign) BOOL hasCancelButton;
 @property (nonatomic, assign) BOOL hasDestructiveButton;


### PR DESCRIPTION
I realized the properties of basic alert references inside `RMUniversalAlert` doesn't have memory management attributes.

As you know, the default property attributes with ARC is `strong`.
- https://useyourloaf.com/blog/default-property-attributes-with-arc/

```objective-c
@property NSArray *name;
@property (strong, atomic, readwrite) NSArray *name;
```

I think they don't need to be strong references.
It causes  memory leak sometimes since iOS 11. 

So, I add `weak` attribute on the properties.

```objective-c
@property (nonatomic, weak) UIAlertController *alertController;
@property (nonatomic, weak) UIAlertView *alertView;
@property (nonatomic, weak) UIActionSheet *actionSheet;
```

Could you check this  out, please?
